### PR TITLE
FIX: await start

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 const entropy = 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'; // change that
 RnLdk.setStorage(AsyncStorage);
 RnLdk.setRefundAddressScript('76a91419129d53e6319baf19dba059bead166df90ab8f588ac'); // 13HaCAB4jf7FYSZexJxoczyDDnutzZigjS
-RnLdk.start(entropy).then(console.warn);
+await RnLdk.start(entropy).then(console.warn);
 
 // lets create a channel
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -32,7 +32,7 @@ export default function App() {
 
           RnLdk.setStorage(syncedStorage);
           RnLdk.setRefundAddressScript('76a91419129d53e6319baf19dba059bead166df90ab8f588ac'); // 13HaCAB4jf7FYSZexJxoczyDDnutzZigjS
-          RnLdk.start(entropy).then(console.warn);
+          await RnLdk.start(entropy).then(console.warn);
         }}
         title="Start"
         color="#841584"


### PR DESCRIPTION
If I call another APIs without waiting for `start`, I get an error.