### PR TITLE
Add bitcoinjs-lib dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
+  "dependencies": {
+    "bitcoinjs-lib": "^6.0.1"
+  },
   "devDependencies": {
     "@commitlint/config-conventional": "^11.0.0",
     "@react-native-community/eslint-config": "^2.0.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import { NativeEventEmitter, NativeModules, Alert } from 'react-native';
+import * as bitcoin from 'bitcoinjs-lib';
 import utils from './util';
 const { RnLdk: RnLdkNative } = NativeModules;
 const pckg = require('../package.json');
@@ -263,9 +264,7 @@ class RnLdkImplementation {
     if (this.injectedScript2address) {
       return await this.injectedScript2address(scriptHex);
     }
-
-    const response = await fetch('https://runkit.io/overtorment/output-script-to-address/branches/master/' + scriptHex);
-    return response.text();
+    return bitcoin.address.fromOutputScript(Buffer.from(scriptHex, 'hex'));
   }
 
   /**


### PR DESCRIPTION
This PR:
 - Adds `bitcoinjs-lib` as a dependency.
 - Replaces the fetch request to `https://runkit.io/overtorment/output-script-to-address/branches/master/` in the `script2address` method with the bitcoinjs-lib implementation. 