### PR TITLE
Bump LDK iOS to 110

### DIFF
--- a/ios/RnLdk.xcodeproj/project.pbxproj
+++ b/ios/RnLdk.xcodeproj/project.pbxproj
@@ -3,11 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		6D13AC53264EC461002CC78F /* ReactEventEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D13AC52264EC461002CC78F /* ReactEventEmitter.m */; };
+		75089ECB28B499F800D4E56E /* LightningDevKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75089ECA28B499F800D4E56E /* LightningDevKit.xcframework */; };
 		E5094CD0268A934F00C60D88 /* RnLdk.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RnLdk.m */; };
 		F4FF95D7245B92E800C19C63 /* RnLdk.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF95D6245B92E800C19C63 /* RnLdk.swift */; };
 /* End PBXBuildFile section */
@@ -28,6 +29,7 @@
 		134814201AA4EA6300B7C361 /* libRnLdk.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRnLdk.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		6D13AC51264EC461002CC78F /* ReactEventEmitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReactEventEmitter.h; sourceTree = "<group>"; };
 		6D13AC52264EC461002CC78F /* ReactEventEmitter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReactEventEmitter.m; sourceTree = "<group>"; };
+		75089ECA28B499F800D4E56E /* LightningDevKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = LightningDevKit.xcframework; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RnLdk.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RnLdk.m; sourceTree = "<group>"; };
 		F4FF95D5245B92E700C19C63 /* RnLdk-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RnLdk-Bridging-Header.h"; sourceTree = "<group>"; };
 		F4FF95D6245B92E800C19C63 /* RnLdk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RnLdk.swift; sourceTree = "<group>"; };
@@ -38,6 +40,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				75089ECB28B499F800D4E56E /* LightningDevKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -55,6 +58,7 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				75089ECA28B499F800D4E56E /* LightningDevKit.xcframework */,
 				6D13AC51264EC461002CC78F /* ReactEventEmitter.h */,
 				6D13AC52264EC461002CC78F /* ReactEventEmitter.m */,
 				F4FF95D6245B92E800C19C63 /* RnLdk.swift */,

--- a/ios/RnLdk.xcodeproj/project.pbxproj
+++ b/ios/RnLdk.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6D13AC53264EC461002CC78F /* ReactEventEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D13AC52264EC461002CC78F /* ReactEventEmitter.m */; };
-		75089ECB28B499F800D4E56E /* LightningDevKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75089ECA28B499F800D4E56E /* LightningDevKit.xcframework */; };
+		75089ECD28B49F7C00D4E56E /* LightningDevKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75089ECC28B49F7C00D4E56E /* LightningDevKit.xcframework */; };
 		E5094CD0268A934F00C60D88 /* RnLdk.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RnLdk.m */; };
 		F4FF95D7245B92E800C19C63 /* RnLdk.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF95D6245B92E800C19C63 /* RnLdk.swift */; };
 /* End PBXBuildFile section */
@@ -29,7 +29,7 @@
 		134814201AA4EA6300B7C361 /* libRnLdk.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRnLdk.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		6D13AC51264EC461002CC78F /* ReactEventEmitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReactEventEmitter.h; sourceTree = "<group>"; };
 		6D13AC52264EC461002CC78F /* ReactEventEmitter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReactEventEmitter.m; sourceTree = "<group>"; };
-		75089ECA28B499F800D4E56E /* LightningDevKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = LightningDevKit.xcframework; sourceTree = "<group>"; };
+		75089ECC28B49F7C00D4E56E /* LightningDevKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = LightningDevKit.xcframework; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RnLdk.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RnLdk.m; sourceTree = "<group>"; };
 		F4FF95D5245B92E700C19C63 /* RnLdk-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RnLdk-Bridging-Header.h"; sourceTree = "<group>"; };
 		F4FF95D6245B92E800C19C63 /* RnLdk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RnLdk.swift; sourceTree = "<group>"; };
@@ -40,7 +40,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				75089ECB28B499F800D4E56E /* LightningDevKit.xcframework in Frameworks */,
+				75089ECD28B49F7C00D4E56E /* LightningDevKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -58,7 +58,7 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
-				75089ECA28B499F800D4E56E /* LightningDevKit.xcframework */,
+				75089ECC28B49F7C00D4E56E /* LightningDevKit.xcframework */,
 				6D13AC51264EC461002CC78F /* ReactEventEmitter.h */,
 				6D13AC52264EC461002CC78F /* ReactEventEmitter.m */,
 				F4FF95D6245B92E800C19C63 /* RnLdk.swift */,

--- a/rn-ldk.podspec
+++ b/rn-ldk.podspec
@@ -19,5 +19,4 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
   s.vendored_frameworks = "ios/LightningDevKit.xcframework"
-
 end


### PR DESCRIPTION
Crucially, we drop `LightningDevKit.xcframework` into `RnLdk.xcodeproj` instead of **just** exposing it via `vendored_framework` in `.podspec`. 

I only got as far as to test that `pod install` works for the example app. I reckon the actual project itself (the Swift file) needs updating. 

<img width="1571" alt="image" src="https://user-images.githubusercontent.com/5944973/186076897-789b2e20-5097-480d-bee0-4e3589aa2c55.png">

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/5944973/186079665-210fb8ce-3714-4903-8214-a0088b4703c3.png">

